### PR TITLE
Clarify Flex Consumption zone redundancy cost impact

### DIFF
--- a/articles/reliability/reliability-functions.md
+++ b/articles/reliability/reliability-functions.md
@@ -190,13 +190,15 @@ When Functions allocates instances to a zone-redundant Premium plan, it uses [be
 
 ::: zone pivot="flex-consumption,premium"
 
-You incur no extra cost when you enable zone redundancy. Pricing for a zone-redundant plan is the same as a single-zone plan. However, enabling zone redundancy affects the minimum number of instances in your plan.
+Enabling zone redundancy doesn't add a separate charge. There's no extra meter for the zone redundancy feature itself, and the per-instance price for a zone-redundant plan is the same as for a single-zone plan. However, enabling zone redundancy increases the minimum number of instances your plan must run, which can increase your bill. Review the plan-specific details that follow before you enable zone redundancy in production.
 
 ::: zone-end
 
 ::: zone pivot="flex-consumption"
 
 When you enable availability zones in an app with an always-ready instance configuration of fewer than two instances for each [per-function scaling function or group](/azure/azure-functions/flex-consumption-plan#per-function-scaling), the platform automatically creates two instances of the [always-ready type](/azure/azure-functions/flex-consumption-plan#always-ready-instances) for each per-function scaling function or group. These new instances are also billed as always-ready instances.
+
+Because at least two always-ready instances are required for each per-function scaling function or group while zone redundancy is enabled, a zone-redundant Flex Consumption app doesn't scale to zero. Apps that were previously idle most of the time can see a cost increase after you enable zone redundancy, because the required instances incur the nominal always-ready baseline meter continuously (even when idle), and add the always-ready execution time meter on top while actively executing. For meter definitions and rates, see [Azure Functions pricing](https://azure.microsoft.com/pricing/details/functions/).
 
 ::: zone-end
 


### PR DESCRIPTION
## Why

The Cost section under the **Flex Consumption** pivot of [Reliability in Azure Functions](https://learn.microsoft.com/en-us/azure/reliability/reliability-functions?pivots=flex-consumption#cost) currently opens with:

> You incur no extra cost when you enable zone redundancy. Pricing for a zone-redundant plan is the same as a single-zone plan.

This has been read by customers as "zone redundancy is free." Recent customer escalation: an Azure Functions customer enabled zone redundancy across their Flex Consumption apps and reported their bill more than doubled, because the enforced minimum of two always-ready instances per per-function scaling function or group means a zone-redundant Flex Consumption app no longer scales to zero.

The intent of the original sentence is that there's no separate meter for the zone redundancy feature itself \u2014 not that enabling it has zero billing impact. This PR makes that distinction explicit and calls out the scale-to-zero implication for Flex Consumption.

## Changes

`articles/reliability/reliability-functions.md` \u2014 Cost section (Flex Consumption + Premium shared, then Flex-specific):

1. Reword the shared paragraph so it's clear there's no separate ZR meter, but the enforced minimum instance count can increase the bill.
2. Add a Flex-specific paragraph explaining:
   - A zone-redundant Flex Consumption app doesn't scale to zero.
   - The required always-ready instances incur the **nominal always-ready baseline meter** continuously (even when idle), and add the **always-ready execution time meter** on top while actively executing.
   - Link to [Azure Functions pricing](https://azure.microsoft.com/pricing/details/functions/) for meter definitions and rates.